### PR TITLE
add opt paths

### DIFF
--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -1,5 +1,19 @@
 require 'mkmf'
 
+HEADER_DIRS = [
+  '/opt/flydata/include',
+  '/usr/local/include',
+  '/usr/include',
+]
+
+LIB_DIRS = [
+  '/opt/flydata/lib',
+  '/usr/local/lib',
+  '/usr/lib',
+]
+
+dir_config('replication', HEADER_DIRS, LIB_DIRS)
+
 if have_library('stdc++') and have_library('replication')
   create_makefile('binlog')
 end


### PR DESCRIPTION
Add /opt/flydata paths to prepare for installation of flydata-mysql-replication-listener package. This should default to normal if it doesn't find it in /opt/flydata.