### PR TITLE
@T2299:R Fixed a bug where a binary string was cut off at a null byte.

### DIFF
--- a/ext/ruby_binlog_row_event.cpp
+++ b/ext/ruby_binlog_row_event.cpp
@@ -229,7 +229,7 @@ void RowEvent::proc0(mysql::Row_of_fields &fields, VALUE rb_fields) {
     } else {
       std::string out;
       converter.to(out, *itor);
-      rval = rb_str_new2(out.c_str());
+      rval = rb_str_new(out.c_str(), out.length());
     }
 
     rb_ary_push(rb_fields, rval);


### PR DESCRIPTION
mysql-replication-listener returns a std::string object which handles null bytes correctly.  Changed the code to create a Ruby string using its length.  `rb_str_new()` is a method which creates ruby string from a pointer and a length.