### PR TITLE
[WIP] Feature/u1141 support latest replication

### DIFF
--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -1,5 +1,8 @@
 require 'mkmf'
 
+dir_config('replication')
+dir_config('mysql')
+
 if have_library('stdc++') and have_library('replication')
   create_makefile('binlog')
 end

--- a/ext/ruby_binlog.h
+++ b/ext/ruby_binlog.h
@@ -5,8 +5,8 @@
 #define private public
 
 #include <string>
-#include <binlog_api.h>
 #include <ruby.h>
+#include <binlog_api.h>
 
 #ifndef RUBY_UBF_IO
 #include <rubysig.h>
@@ -34,7 +34,7 @@ extern VALUE rb_eBinlogError;
 
 namespace ruby {
 namespace binlog {
-const char* get_field_type_str(mysql::system::enum_field_types type);
+const char* get_field_type_str(enum_field_types type);
 mysql::system::Binlog_tcp_driver *cast_to_tcp_driver(mysql::system::Binary_log_driver *driver);
 } // namespace binlog
 } // namespace ruby

--- a/ext/ruby_binlog_get_field_type_str.cpp
+++ b/ext/ruby_binlog_get_field_type_str.cpp
@@ -3,35 +3,35 @@
 namespace ruby {
 namespace binlog {
 
-const char* get_field_type_str(mysql::system::enum_field_types type) {
+const char* get_field_type_str(enum_field_types type) {
   switch(type) {
-  case mysql::system::MYSQL_TYPE_DECIMAL:     return "DECIMAL";     break;
-  case mysql::system::MYSQL_TYPE_TINY:        return "TINY";        break;
-  case mysql::system::MYSQL_TYPE_SHORT:       return "SHORT";       break;
-  case mysql::system::MYSQL_TYPE_LONG:        return "LONG";        break;
-  case mysql::system::MYSQL_TYPE_FLOAT:       return "FLOAT";       break;
-  case mysql::system::MYSQL_TYPE_DOUBLE:      return "DOUBLE";      break;
-  case mysql::system::MYSQL_TYPE_NULL:        return "NULL";        break;
-  case mysql::system::MYSQL_TYPE_TIMESTAMP:   return "TIMESTAMP";   break;
-  case mysql::system::MYSQL_TYPE_LONGLONG:    return "LONGLONG";    break;
-  case mysql::system::MYSQL_TYPE_INT24:       return "INT24";       break;
-  case mysql::system::MYSQL_TYPE_DATE:        return "DATE";        break;
-  case mysql::system::MYSQL_TYPE_TIME:        return "TIME";        break;
-  case mysql::system::MYSQL_TYPE_DATETIME:    return "DATETIME";    break;
-  case mysql::system::MYSQL_TYPE_YEAR:        return "YEAR";        break;
-  case mysql::system::MYSQL_TYPE_NEWDATE:     return "NEWDATE";     break;
-  case mysql::system::MYSQL_TYPE_VARCHAR:     return "VARCHAR";     break;
-  case mysql::system::MYSQL_TYPE_BIT:         return "BIT";         break;
-  case mysql::system::MYSQL_TYPE_NEWDECIMAL:  return "NEWDECIMAL";  break;
-  case mysql::system::MYSQL_TYPE_ENUM:        return "ENUM";        break;
-  case mysql::system::MYSQL_TYPE_SET:         return "SET";         break;
-  case mysql::system::MYSQL_TYPE_TINY_BLOB:   return "TINY_BLOB";   break;
-  case mysql::system::MYSQL_TYPE_MEDIUM_BLOB: return "MEDIUM_BLOB"; break;
-  case mysql::system::MYSQL_TYPE_LONG_BLOB:   return "LONG_BLOB";   break;
-  case mysql::system::MYSQL_TYPE_BLOB:        return "BLOB";        break;
-  case mysql::system::MYSQL_TYPE_VAR_STRING:  return "VAR_STRING";  break;
-  case mysql::system::MYSQL_TYPE_STRING:      return "STRING";      break;
-  case mysql::system::MYSQL_TYPE_GEOMETRY:    return "GEOMETRY";    break;
+  case MYSQL_TYPE_DECIMAL:     return "DECIMAL";     break;
+  case MYSQL_TYPE_TINY:        return "TINY";        break;
+  case MYSQL_TYPE_SHORT:       return "SHORT";       break;
+  case MYSQL_TYPE_LONG:        return "LONG";        break;
+  case MYSQL_TYPE_FLOAT:       return "FLOAT";       break;
+  case MYSQL_TYPE_DOUBLE:      return "DOUBLE";      break;
+  case MYSQL_TYPE_NULL:        return "NULL";        break;
+  case MYSQL_TYPE_TIMESTAMP:   return "TIMESTAMP";   break;
+  case MYSQL_TYPE_LONGLONG:    return "LONGLONG";    break;
+  case MYSQL_TYPE_INT24:       return "INT24";       break;
+  case MYSQL_TYPE_DATE:        return "DATE";        break;
+  case MYSQL_TYPE_TIME:        return "TIME";        break;
+  case MYSQL_TYPE_DATETIME:    return "DATETIME";    break;
+  case MYSQL_TYPE_YEAR:        return "YEAR";        break;
+  case MYSQL_TYPE_NEWDATE:     return "NEWDATE";     break;
+  case MYSQL_TYPE_VARCHAR:     return "VARCHAR";     break;
+  case MYSQL_TYPE_BIT:         return "BIT";         break;
+  case MYSQL_TYPE_NEWDECIMAL:  return "NEWDECIMAL";  break;
+  case MYSQL_TYPE_ENUM:        return "ENUM";        break;
+  case MYSQL_TYPE_SET:         return "SET";         break;
+  case MYSQL_TYPE_TINY_BLOB:   return "TINY_BLOB";   break;
+  case MYSQL_TYPE_MEDIUM_BLOB: return "MEDIUM_BLOB"; break;
+  case MYSQL_TYPE_LONG_BLOB:   return "LONG_BLOB";   break;
+  case MYSQL_TYPE_BLOB:        return "BLOB";        break;
+  case MYSQL_TYPE_VAR_STRING:  return "VAR_STRING";  break;
+  case MYSQL_TYPE_STRING:      return "STRING";      break;
+  case MYSQL_TYPE_GEOMETRY:    return "GEOMETRY";    break;
   }
 
   return 0;

--- a/ext/ruby_binlog_row_event.cpp
+++ b/ext/ruby_binlog_row_event.cpp
@@ -107,7 +107,7 @@ VALUE RowEvent::get_column_types(VALUE self) {
 
     for (std::vector<uint8_t>::iterator itor = tme->m_event->columns.begin();
          itor != tme->m_event->columns.end(); itor++) {
-      const char *colname = get_field_type_str(static_cast<mysql::system::enum_field_types>(*itor));
+      const char *colname = get_field_type_str(static_cast<enum_field_types>(*itor));
       rb_ary_push(retval, (colname ? rb_str_new2(colname) : Qnil));
     }
   }
@@ -218,13 +218,13 @@ void RowEvent::proc0(mysql::Row_of_fields &fields, VALUE rb_fields) {
 
   do {
     VALUE rval = Qnil;
-    mysql::system::enum_field_types type = itor->type();
+    enum_field_types type = itor->type();
 
     if (itor->is_null()) {
       rval = Qnil;
-    } else if (type == mysql::system::MYSQL_TYPE_FLOAT) {
+    } else if (type == MYSQL_TYPE_FLOAT) {
       rval = rb_float_new(itor->as_float());
-    } else if (type == mysql::system::MYSQL_TYPE_DOUBLE) {
+    } else if (type == MYSQL_TYPE_DOUBLE) {
       rval = rb_float_new(itor->as_double());
     } else {
       std::string out;

--- a/ext/ruby_binlog_table_map_event.cpp
+++ b/ext/ruby_binlog_table_map_event.cpp
@@ -96,7 +96,7 @@ VALUE TableMapEvent::get_column_types(VALUE self) {
 
   for (std::vector<uint8_t>::iterator itor = p->m_event->columns.begin();
        itor != p->m_event->columns.end(); itor++) {
-    const char *colname = get_field_type_str(static_cast<mysql::system::enum_field_types>(*itor));
+    const char *colname = get_field_type_str(static_cast<enum_field_types>(*itor));
     rb_ary_push(retval, (colname ? rb_str_new2(colname) : Qnil));
   }
 


### PR DESCRIPTION
__NOTE:  This change breaks compatibility. Don't merge until ready to release.__

This change is for supporting latest mysql-replication-listener which uses mysql client library instead of boost. Since ruby-binlog refers depricated api and internal member variables of replication, some codes needed to be changed. 

Todos
  - [x] Support configuring mysql and replication install path
  - [x] Use connecting() method of replication which is implemented for ruby-binlog
  - [x] Solve compile issue
  - [] Solve macro definitions conflict between `my_global.h` and `ruby.h`
  - [] Implement better handling for binlog event to take care of connection errors.
