### PR TITLE
add options for mysql replication listener library detection

### DIFF
--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -1,23 +1,6 @@
 require 'mkmf'
 
-LIBDIR      = RbConfig::CONFIG['libdir']
-INCLUDEDIR  = RbConfig::CONFIG['includedir']
-
-HEADER_DIRS = [
-  '/opt/local/include',
-  '/usr/local/include',
-  INCLUDEDIR,
-  '/usr/include',
-]
-
-LIB_DIRS = [
-  '/opt/local/lib',
-  '/usr/local/lib',
-  LIBDIR,
-  '/usr/lib',
-]
-
-dir_config('replication', HEADER_DIRS, LIB_DIRS)
+dir_config('replication')
 
 case explicit_rpath = with_config('replication-rpath')
 when true

--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -19,6 +19,18 @@ LIB_DIRS = [
 
 dir_config('replication', HEADER_DIRS, LIB_DIRS)
 
+case explicit_rpath = with_config('replication-rpath')
+when true
+  abort "-----\nOption --with-replication-rpath must have an argument\n-----"
+when false
+  warn "-----\nOption --with-replication-rpath has been disabled at your request\n-----"
+when String
+  # The user gave us a value so use it
+  rpath_flags = " -Wl,-rpath,#{explicit_rpath}"
+  warn "-----\nSetting replication rpath to #{explicit_rpath}\n-----"
+  $LDFLAGS << rpath_flags
+end
+
 if have_library('stdc++') and have_library('replication')
   create_makefile('binlog')
 end

--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -1,5 +1,24 @@
 require 'mkmf'
 
+LIBDIR      = RbConfig::CONFIG['libdir']
+INCLUDEDIR  = RbConfig::CONFIG['includedir']
+
+HEADER_DIRS = [
+  '/opt/local/include',
+  '/usr/local/include',
+  INCLUDEDIR,
+  '/usr/include',
+]
+
+LIB_DIRS = [
+  '/opt/local/lib',
+  '/usr/local/lib',
+  LIBDIR,
+  '/usr/lib',
+]
+
+dir_config('replication', HEADER_DIRS, LIB_DIRS)
+
 if have_library('stdc++') and have_library('replication')
   create_makefile('binlog')
 end

--- a/ruby-binlog.gemspec
+++ b/ruby-binlog.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name              = 'ruby-binlog'
-  spec.version           = '1.0.5'
+  spec.version           = '1.0.4'
   spec.summary           = 'Ruby binding for MySQL Binary log API.'
   spec.description       = 'Ruby binding for MySQL Binary log API.'
   spec.files             = Dir.glob('ext/{*.cpp,*.h,extconf.rb}') + %w(README)

--- a/ruby-binlog.gemspec
+++ b/ruby-binlog.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name              = 'ruby-binlog'
-  spec.version           = '1.0.4'
+  spec.version           = '1.0.5'
   spec.summary           = 'Ruby binding for MySQL Binary log API.'
   spec.description       = 'Ruby binding for MySQL Binary log API.'
   spec.files             = Dir.glob('ext/{*.cpp,*.h,extconf.rb}') + %w(README)


### PR DESCRIPTION
When using these options, you can provide custom directories for the
replication library and headers:

--with-replication-lib=
--with-replication-include=

ex.
$ ruby extconf.rb
-with-replication-lib=~/mysql-replication-listener-master/lib
--with-replication-include=~/mysql-replication-listener-master/include