### PR TITLE
Support openssl configuration

### DIFF
--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -1,5 +1,6 @@
 require 'mkmf'
 
+# mysql-replication-listener
 dir_config('replication')
 
 case explicit_rpath = with_config('replication-rpath')
@@ -11,6 +12,21 @@ when String
   # The user gave us a value so use it
   rpath_flags = " -Wl,-rpath,#{explicit_rpath}"
   warn "-----\nSetting replication rpath to #{explicit_rpath}\n-----"
+  $LDFLAGS << rpath_flags
+end
+
+# OpenSSL
+dir_config('openssl')
+
+case explicit_rpath = with_config('openssl-rpath')
+when true
+  abort "-----\nOption --with-openssl-rpath must have an argument\n-----"
+when false
+  warn "-----\nOption --with-openssl-rpath has been disabled at your request\n-----"
+when String
+  # The user gave us a value so use it
+  rpath_flags = " -Wl,-rpath,#{explicit_rpath}"
+  warn "-----\nSetting openssl rpath to #{explicit_rpath}\n-----"
   $LDFLAGS << rpath_flags
 end
 


### PR DESCRIPTION
This change is for dev environment on MacOSX El Capitan, but it should not affect the behavior for production use. In El Capitan, OpenSSL is not installed into the common directory, but itnto the homebrew directory. So, I needed to specify a custom path when compiling ruby-binlog.