### PR TITLE
fix issue where is_closed? is returning false when tcp driver has been deleted and fix a small memory leak

### DIFF
--- a/ext/ruby_binlog.cpp
+++ b/ext/ruby_binlog.cpp
@@ -127,7 +127,7 @@ struct Client {
     driver = cast_to_tcp_driver(p->m_binlog->m_driver);
 
     if (!driver) {
-      return Qfalse;
+      return Qtrue;
     }
 
     if (driver->m_socket) {

--- a/ext/ruby_binlog.cpp
+++ b/ext/ruby_binlog.cpp
@@ -63,6 +63,7 @@ struct Client {
 
   static VALUE connect(VALUE self) {
     Client *p;
+    VALUE rberr=NULL;
     int result;
 
     Data_Get_Struct(self, Client, p);
@@ -72,8 +73,11 @@ struct Client {
     try {
       result = p->m_binlog->connect();
     } catch (const std::exception& e) {
-      rb_raise(rb_eBinlogError, "%s", e.what());
+      rberr = rb_exc_new2(rb_eBinlogError, e.what());
     }
+    
+    if (rberr)
+      rb_exc_raise(rberr);
 #ifndef RUBY_UBF_IO
     TRAP_END;
 #endif


### PR DESCRIPTION
This fixes two issues:
1) I added code in: https://github.com/hapyrus/mysql-replication-listener/pull/34 which deletes the tcp driver upon connection errors to avoid too many sockets being opened.  However, I noticed that is_closed? returns false when the tcp driver has been deleted which causes kodama not to reconnect properly.  This changes it to return true if the tcp driver has been deleted.  I didn't observe any negative side effects from changing this behavior.

2) I fixed a very slow growing memory leak when reconnecting over and over. I think the C++ exception object is not being freed since rb_raise does a longjmp out of this method and never returns.  I looked at some other gems to see how they handled c++ exceptions and followed that pattern.  I didn't notice any memory leaks after rewriting this.